### PR TITLE
[FEAT] 특정 식당의 조기 마감, 고정 운영 시간 변경 기능

### DIFF
--- a/src/main/java/sch_helper/sch_manager/domain/menu/controller/AdminMenuController.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/controller/AdminMenuController.java
@@ -11,6 +11,7 @@ import sch_helper.sch_manager.common.util.DateUtil;
 import sch_helper.sch_manager.domain.menu.dto.EarlyCloseRequestDTO;
 import sch_helper.sch_manager.domain.menu.dto.PendingDailyMealRequestDTO;
 import sch_helper.sch_manager.domain.menu.dto.PendingWeeklyMealRequestDTO;
+import sch_helper.sch_manager.domain.menu.dto.TotalOperatingTimeRequestDTO;
 import sch_helper.sch_manager.domain.menu.dto.base.DailyMealRequestDTO;
 import sch_helper.sch_manager.domain.menu.service.AdminMenuService;
 
@@ -88,5 +89,14 @@ public class AdminMenuController {
             @RequestBody EarlyCloseRequestDTO earlyCloseRequestDTO
     ) {
         return adminMenuService.earlyClose(restaurantName, earlyCloseRequestDTO);
+    }
+
+    // 고정 운영시간 변경
+    @PostMapping("/total-operating-time/{restaurant-name}")
+    public ResponseEntity<?> updateTotalOperatingTime(
+            @PathVariable(name = "restaurant-name") @Valid String restaurantName,
+            @RequestBody TotalOperatingTimeRequestDTO request
+    ) {
+        return adminMenuService.updateTotalOperatingTime(restaurantName, request);
     }
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/controller/AdminMenuController.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/controller/AdminMenuController.java
@@ -8,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import sch_helper.sch_manager.common.exception.custom.ApiException;
 import sch_helper.sch_manager.common.exception.error.ErrorCode;
 import sch_helper.sch_manager.common.util.DateUtil;
+import sch_helper.sch_manager.domain.menu.dto.EarlyCloseRequestDTO;
 import sch_helper.sch_manager.domain.menu.dto.PendingDailyMealRequestDTO;
 import sch_helper.sch_manager.domain.menu.dto.PendingWeeklyMealRequestDTO;
 import sch_helper.sch_manager.domain.menu.dto.base.DailyMealRequestDTO;
@@ -78,5 +79,14 @@ public class AdminMenuController {
         }
 
         return adminMenuService.getPendingDailyMealPlans(pendingDailyMealRequestDTO);
+    }
+
+    // 조기마감하기
+    @PostMapping("/early-close/{restaurant-name}")
+    public ResponseEntity<?> earlyClose(
+            @PathVariable(name = "restaurant-name") @Valid String restaurantName,
+            @RequestBody EarlyCloseRequestDTO earlyCloseRequestDTO
+    ) {
+        return adminMenuService.earlyClose(restaurantName, earlyCloseRequestDTO);
     }
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/controller/AdminMenuController.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/controller/AdminMenuController.java
@@ -85,8 +85,8 @@ public class AdminMenuController {
     // 조기마감하기
     @PostMapping("/early-close/{restaurant-name}")
     public ResponseEntity<?> earlyClose(
-            @PathVariable(name = "restaurant-name") @Valid String restaurantName,
-            @RequestBody EarlyCloseRequestDTO earlyCloseRequestDTO
+            @PathVariable(name = "restaurant-name") String restaurantName,
+            @RequestBody @Valid EarlyCloseRequestDTO earlyCloseRequestDTO
     ) {
         return adminMenuService.earlyClose(restaurantName, earlyCloseRequestDTO);
     }
@@ -94,8 +94,8 @@ public class AdminMenuController {
     // 고정 운영시간 변경
     @PostMapping("/total-operating-time/{restaurant-name}")
     public ResponseEntity<?> updateTotalOperatingTime(
-            @PathVariable(name = "restaurant-name") @Valid String restaurantName,
-            @RequestBody TotalOperatingTimeRequestDTO request
+            @PathVariable(name = "restaurant-name") String restaurantName,
+            @RequestBody @Valid TotalOperatingTimeRequestDTO request
     ) {
         return adminMenuService.updateTotalOperatingTime(restaurantName, request);
     }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/EarlyCloseRequestDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/EarlyCloseRequestDTO.java
@@ -1,0 +1,17 @@
+package sch_helper.sch_manager.domain.menu.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EarlyCloseRequestDTO {
+
+    // mealType 은 필요 없으므로 넣지 않음
+
+    @NotBlank
+    private boolean earlyClose;
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/EarlyCloseResponseDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/EarlyCloseResponseDTO.java
@@ -1,0 +1,17 @@
+package sch_helper.sch_manager.domain.menu.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class EarlyCloseResponseDTO {
+
+    private String restaurantName;
+    private String operatingStartTime;
+    private String operatingEndTime;
+    private boolean isActive;
+
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/TotalOperatingTimeRequestDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/TotalOperatingTimeRequestDTO.java
@@ -1,0 +1,14 @@
+package sch_helper.sch_manager.domain.menu.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TotalOperatingTimeRequestDTO {
+
+    private String newOperatingStartTime;
+    private String newOperatingEndTime;
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/TotalOperatingTimeRequestDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/TotalOperatingTimeRequestDTO.java
@@ -1,5 +1,6 @@
 package sch_helper.sch_manager.domain.menu.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,6 +10,8 @@ import lombok.Setter;
 @NoArgsConstructor
 public class TotalOperatingTimeRequestDTO {
 
+    @NotBlank
     private String newOperatingStartTime;
+    @NotBlank
     private String newOperatingEndTime;
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/base/RestaurantResponseDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/base/RestaurantResponseDTO.java
@@ -1,0 +1,27 @@
+package sch_helper.sch_manager.domain.menu.dto.base;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import sch_helper.sch_manager.domain.menu.entity.Restaurant;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RestaurantResponseDTO {
+
+    private String restaurantName;
+    private String operatingStartTime;
+    private String operatingEndTime;
+    private boolean isActive;
+
+    public static RestaurantResponseDTO fromEntity(Restaurant restaurant) {
+        return new RestaurantResponseDTO(
+                restaurant.getName(),
+                restaurant.getOperatingStartTime(),
+                restaurant.getOperatingEndTime(),
+                restaurant.isActive()
+        );
+    }
+
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/converter/RestaurantConverter.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/converter/RestaurantConverter.java
@@ -1,0 +1,19 @@
+package sch_helper.sch_manager.domain.menu.dto.converter;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import sch_helper.sch_manager.domain.menu.dto.base.RestaurantResponseDTO;
+import sch_helper.sch_manager.domain.menu.entity.Restaurant;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class RestaurantConverter {
+
+    public static RestaurantResponseDTO toResponse(Restaurant restaurant) {
+        return RestaurantResponseDTO.fromEntity(restaurant);
+    }
+
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/entity/Restaurant.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/entity/Restaurant.java
@@ -25,4 +25,9 @@ public class Restaurant {
 
     @Column(name = "is_active", nullable = false)
     private boolean isActive;
+
+    // 조기 마감을 위한 메소드
+    public void changeIsActive(boolean isActive){
+        this.isActive = isActive;
+    }
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/entity/Restaurant.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/entity/Restaurant.java
@@ -30,4 +30,13 @@ public class Restaurant {
     public void changeIsActive(boolean isActive){
         this.isActive = isActive;
     }
+
+    // 고정 운영시간 변경을 위한 메소드
+    public void changeOperatingStartTime(String operatingStartTime) {
+        this.operatingStartTime = operatingStartTime;
+    }
+
+    public void changeOperatingEndTime(String operatingEndTime) {
+        this.operatingEndTime = operatingEndTime;
+    }
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/service/AdminMenuService.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/service/AdminMenuService.java
@@ -231,6 +231,19 @@ public class AdminMenuService {
 
         return ResponseEntity.ok(SuccessResponse.ok(response));
     }
+
+    @Transactional
+    public ResponseEntity<?> updateTotalOperatingTime(String restaurantName, TotalOperatingTimeRequestDTO request) {
+        Restaurant restaurant = restaurantRepository.findByName(restaurantName)
+                .orElseThrow(() -> new ApiException(ErrorCode.RESTAURANT_NOT_FOUND));
+
+        restaurant.changeOperatingStartTime(request.getNewOperatingStartTime());
+        restaurant.changeOperatingEndTime(request.getNewOperatingEndTime());
+
+        RestaurantResponseDTO response = RestaurantConverter.toResponse(restaurant);
+
+        return ResponseEntity.ok(SuccessResponse.ok(response));
+    }
 }
 /*
 POST - http://localhost:8080/api/admin/week-meal-plans/faculty

--- a/src/main/java/sch_helper/sch_manager/domain/menu/service/AdminMenuService.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/service/AdminMenuService.java
@@ -1,5 +1,6 @@
 package sch_helper.sch_manager.domain.menu.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
@@ -11,14 +12,13 @@ import sch_helper.sch_manager.common.exception.error.ErrorCode;
 import sch_helper.sch_manager.common.response.SuccessResponse;
 import sch_helper.sch_manager.common.util.FileUtil;
 import sch_helper.sch_manager.common.util.MenuUtil;
-import sch_helper.sch_manager.domain.menu.dto.PendingDailyMealRequestDTO;
-import sch_helper.sch_manager.domain.menu.dto.PendingDailyMealResponseDTO;
-import sch_helper.sch_manager.domain.menu.dto.PendingWeeklyMealRequestDTO;
-import sch_helper.sch_manager.domain.menu.dto.PendingWeeklyMealResponseDTO;
+import sch_helper.sch_manager.domain.menu.dto.*;
 import sch_helper.sch_manager.domain.menu.dto.base.DailyMealRequestDTO;
 import sch_helper.sch_manager.domain.menu.dto.base.DailyMealResponseDTO;
 import sch_helper.sch_manager.domain.menu.dto.base.MealResponseDTO;
+import sch_helper.sch_manager.domain.menu.dto.base.RestaurantResponseDTO;
 import sch_helper.sch_manager.domain.menu.dto.converter.MenuConverter;
+import sch_helper.sch_manager.domain.menu.dto.converter.RestaurantConverter;
 import sch_helper.sch_manager.domain.menu.entity.Menu;
 import sch_helper.sch_manager.domain.menu.entity.Restaurant;
 import sch_helper.sch_manager.domain.menu.enums.DayOfWeek;
@@ -218,6 +218,18 @@ public class AdminMenuService {
         );
 
         return ResponseEntity.ok(SuccessResponse.ok(pendingDailyMealResponseDTO));
+    }
+
+    @Transactional
+    public ResponseEntity<?> earlyClose(String restaurantName, EarlyCloseRequestDTO earlyCloseRequestDTO) {
+        Restaurant restaurant = restaurantRepository.findByName(restaurantName)
+                .orElseThrow(() -> new ApiException(ErrorCode.RESTAURANT_NOT_FOUND));
+
+        restaurant.changeIsActive(!earlyCloseRequestDTO.isEarlyClose());
+        RestaurantResponseDTO response = RestaurantConverter.toResponse(restaurant);
+
+
+        return ResponseEntity.ok(SuccessResponse.ok(response));
     }
 }
 /*


### PR DESCRIPTION
## 조기 마감
### POST  http://localhost:8080/api/admin/early-close/{restaurantName}
```json
// 요청 header
{
  "Authorization": "Bearer <Access_TOKEN>",
  "Content-Type": "application/json"
}

// 요청 body (json)
{
  "early-close": true/false
}
```
```json
// 응답 body (status code 200)
{
    "status": "OK",
    "message": "Success",
    "data": {
        "restaurantName": "HYANGSEOL1",
        "operatingStartTime": "08:00",
        "operatingEndTime": "12:00",
        "active": false/true
    }
}
```
## 고정 운영 시간 변경
### POST http://localhost:8080/api/admin/total-operating-time/{restaurantName}
```json
// 요청 header
{
  "Authorization": "Bearer <Access_TOKEN>",
  "Content-Type": "application/json"
}

// 요청 body (json)
{
  "newOperatingStartTime": "09:00",
  "newOperatingEndTime": "19:00"
}
```
```json
// 응답 body (status code 200)
{
    "status": "OK",
    "message": "Success",
    "data": {
        "restaurantName": "HYANGSEOL1",
        "operatingStartTime": "08:00",
        "operatingEndTime": "19:00",
        "active": false/true
    }
}
```

## 관련 이슈
### [DB Design] `is_active` 필드 위치 결정 (restaurant vs menu 테이블)

**문제 상황**:
- 현재 `restaurant` 테이블에 존재하는 `is_active` 필드의 적절성 논의
- 메뉴 단위 활성화 관리 필요성 대두

**분석 포인트**:
1. **개념적 정합성**
   - \[is_active\]가 레스토랑 운영 상태인가? 
   - \[is_active\]가 메뉴별 판매 상태인가?

2. **조/중/석식 시간대별로 is_active 필드 변경 필요**
   - 조식 조기 마감시 false로 변경 -> 이후 중식 시간이 되면 다시 true로 변경해야하는 문제 발생

**제안 옵션**:
1. **Option A** : `restaurant` 테이블 유지
- (+) 전체 영업 상태 관리 용이
- (-) 개별 메뉴 상태 제어 불가

2. **Option B** : `menu` 테이블로 이전
- (+) 메뉴 단위 유연한 상태 관리
- (-) 레스토랑 전체 상태 추적 어려움