### PR TITLE
User에 대한 API 추가 및 Master API 수정

### DIFF
--- a/src/main/java/sch_helper/sch_manager/domain/menu/controller/MasterMenuController.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/controller/MasterMenuController.java
@@ -33,7 +33,7 @@ public class MasterMenuController {
             throw new ApiException(ErrorCode.DATE_DAY_MISMATCH);
         }
 
-        return masterMenuService.uploadMasterDailyMealPlans(restaurantName, dailyMealRequestDTO);
+        return masterMenuService.uploadDailyMealPlans(restaurantName, dailyMealRequestDTO);
     }
 
     @GetMapping("/week-meal-plans")

--- a/src/main/java/sch_helper/sch_manager/domain/menu/controller/UserMenuController.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/controller/UserMenuController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sch_helper.sch_manager.common.exception.custom.ApiException;
 import sch_helper.sch_manager.common.exception.error.ErrorCode;
 import sch_helper.sch_manager.domain.menu.enums.DayOfWeek;
+import sch_helper.sch_manager.domain.menu.enums.RestaurantName;
 import sch_helper.sch_manager.domain.menu.service.UserMenuService;
 
 
@@ -37,5 +38,19 @@ public class UserMenuController {
         return userMenuService.getApprovedTodayMealPlans(dayOfWeek);
     }
 
+    @GetMapping("/meal-plans/detail/{restaurant-name}")
+    public ResponseEntity<?> getApprovedDetailMealPlans(@PathVariable("restaurant-name") String restaurantName) {
+
+        if (restaurantName.isEmpty() &&
+                (
+                        !restaurantName.equals(RestaurantName.HYANGSEOL1.toString()) ||
+                        !restaurantName.equals(RestaurantName.FACULTY.toString())
+                )
+        ) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST_DATA);
+        }
+
+        return userMenuService.getApprovedDetailMealPlans(restaurantName);
+    }
 
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/controller/UserMenuController.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/controller/UserMenuController.java
@@ -1,0 +1,41 @@
+package sch_helper.sch_manager.domain.menu.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sch_helper.sch_manager.common.exception.custom.ApiException;
+import sch_helper.sch_manager.common.exception.error.ErrorCode;
+import sch_helper.sch_manager.domain.menu.enums.DayOfWeek;
+import sch_helper.sch_manager.domain.menu.service.UserMenuService;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserMenuController {
+
+    private final UserMenuService userMenuService;
+
+    @GetMapping("/meal-plans/today/{day-of-week}")
+    public ResponseEntity<?> getApprovedTodayMealPlans(@PathVariable("day-of-week") String dayOfWeek) {
+
+        if (dayOfWeek.isEmpty() &&
+                (
+                        !dayOfWeek.equals(DayOfWeek.MONDAY.toString()) ||
+                        !dayOfWeek.equals(DayOfWeek.TUESDAY.toString()) ||
+                        !dayOfWeek.equals(DayOfWeek.WEDNESDAY.toString()) ||
+                        !dayOfWeek.equals(DayOfWeek.THURSDAY.toString()) ||
+                        !dayOfWeek.equals(DayOfWeek.FRIDAY.toString())
+                )
+        ) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST_DATA);
+        }
+
+        return userMenuService.getApprovedTodayMealPlans(dayOfWeek);
+    }
+
+
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/ApprovedDetailMealResponseDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/ApprovedDetailMealResponseDTO.java
@@ -1,0 +1,20 @@
+package sch_helper.sch_manager.domain.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sch_helper.sch_manager.domain.menu.dto.base.DailyMealResponseDTO;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ApprovedDetailMealResponseDTO {
+
+    private String restaurantOperatingStartTime;
+
+    private String restaurantOperatingEndTime;
+
+    private boolean isActive;
+
+    List<DailyMealResponseDTO> dailyMeals;
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/ApprovedTodayMealResponseDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/ApprovedTodayMealResponseDTO.java
@@ -1,0 +1,17 @@
+package sch_helper.sch_manager.domain.menu.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sch_helper.sch_manager.domain.menu.dto.base.DailyMealResponseDTO;
+
+@Getter
+@AllArgsConstructor
+public class ApprovedTodayMealResponseDTO {
+
+    private String restaurantName;
+
+    private boolean isActive;
+
+    private DailyMealResponseDTO dailyMeals;
+}
+

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/PendingDailyMealResponseDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/PendingDailyMealResponseDTO.java
@@ -3,11 +3,9 @@ package sch_helper.sch_manager.domain.menu.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import sch_helper.sch_manager.domain.menu.dto.base.DailyMealResponseDTO;
 
 @Getter
-//@NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PendingDailyMealResponseDTO {
@@ -15,5 +13,5 @@ public class PendingDailyMealResponseDTO {
     private String dayMealImg;
     private String weekMealImg;
 
-    private DailyMealResponseDTO dailyMeals;
+    private DailyMealResponseDTO dailyMeal;
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/base/MealResponseDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/base/MealResponseDTO.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import sch_helper.sch_manager.domain.menu.entity.Menu;
-import sch_helper.sch_manager.domain.menu.enums.MealType;
 
 @Getter
 @Setter

--- a/src/main/java/sch_helper/sch_manager/domain/menu/entity/Restaurant.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/entity/Restaurant.java
@@ -14,7 +14,7 @@ public class Restaurant {
     @Column(name = "restaurant_id")
     private Long id;
 
-    @Column(name = "restaurant_name", nullable = false)
+    @Column(name = "restaurant_name", nullable = false, unique = true)
     private String name;
 
     @Column(name = "operating_start_time", nullable = false)

--- a/src/main/java/sch_helper/sch_manager/domain/menu/enums/RestaurantName.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/enums/RestaurantName.java
@@ -1,6 +1,6 @@
 package sch_helper.sch_manager.domain.menu.enums;
 
-public enum Restaurant {
+public enum RestaurantName {
 
     HYANGSEOL1,    // 향설1
     FACULTY  // 교직원

--- a/src/main/java/sch_helper/sch_manager/domain/menu/service/UserMenuService.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/service/UserMenuService.java
@@ -7,6 +7,7 @@ import sch_helper.sch_manager.common.exception.custom.ApiException;
 import sch_helper.sch_manager.common.exception.error.ErrorCode;
 import sch_helper.sch_manager.common.response.SuccessResponse;
 import sch_helper.sch_manager.common.util.MenuUtil;
+import sch_helper.sch_manager.domain.menu.dto.ApprovedDetailMealResponseDTO;
 import sch_helper.sch_manager.domain.menu.dto.ApprovedTodayMealResponseDTO;
 import sch_helper.sch_manager.domain.menu.dto.base.DailyMealResponseDTO;
 import sch_helper.sch_manager.domain.menu.dto.base.MealResponseDTO;
@@ -54,6 +55,26 @@ public class UserMenuService {
         }
 
         return ResponseEntity.ok(SuccessResponse.ok(approvedTodayMealResponseDTOs));
+    }
+
+    public ResponseEntity<?> getApprovedDetailMealPlans(String restaurantName) {
+
+        Restaurant restaurant = restaurantRepository.findByName(restaurantName)
+                .orElseThrow(() -> new ApiException(ErrorCode.RESTAURANT_NOT_FOUND));
+
+        String restaurantOperatingStartTime = restaurant.getOperatingStartTime();
+        String restaurantOperatingEndTime = restaurant.getOperatingEndTime();
+        boolean isActive = restaurant.isActive();
+
+        List<DailyMealResponseDTO> dailyMealResponseDTOs = MenuConverter.getDailyMealResponseDTOsByMenus(
+                menuUtil.getWeeklyMealsByMenuStatus(restaurantName, MenuStatus.APPROVED));
+
+        return ResponseEntity.ok(SuccessResponse.ok(new ApprovedDetailMealResponseDTO(
+                restaurantOperatingStartTime,
+                restaurantOperatingEndTime,
+                isActive,
+                dailyMealResponseDTOs)
+        ));
     }
 
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/service/UserMenuService.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/service/UserMenuService.java
@@ -1,0 +1,59 @@
+package sch_helper.sch_manager.domain.menu.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import sch_helper.sch_manager.common.exception.custom.ApiException;
+import sch_helper.sch_manager.common.exception.error.ErrorCode;
+import sch_helper.sch_manager.common.response.SuccessResponse;
+import sch_helper.sch_manager.common.util.MenuUtil;
+import sch_helper.sch_manager.domain.menu.dto.ApprovedTodayMealResponseDTO;
+import sch_helper.sch_manager.domain.menu.dto.base.DailyMealResponseDTO;
+import sch_helper.sch_manager.domain.menu.dto.base.MealResponseDTO;
+import sch_helper.sch_manager.domain.menu.dto.converter.MenuConverter;
+import sch_helper.sch_manager.domain.menu.entity.Restaurant;
+import sch_helper.sch_manager.domain.menu.enums.DayOfWeek;
+import sch_helper.sch_manager.domain.menu.enums.MenuStatus;
+import sch_helper.sch_manager.domain.menu.enums.RestaurantName;
+import sch_helper.sch_manager.domain.menu.repository.RestaurantRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserMenuService {
+
+    private final MenuUtil menuUtil;
+    private final RestaurantRepository restaurantRepository;
+
+    public ResponseEntity<?> getApprovedTodayMealPlans(String dayOfWeek) {
+
+        List<ApprovedTodayMealResponseDTO> approvedTodayMealResponseDTOs = new ArrayList<>();
+
+        for (RestaurantName restaurant : RestaurantName.values()) {
+
+            Restaurant restaurantEntity = restaurantRepository.findByName(restaurant.name())
+                    .orElseThrow(() -> new ApiException(ErrorCode.RESTAURANT_NOT_FOUND));
+
+            String restaurantName = restaurantEntity.getName();
+            boolean isActive = restaurantEntity.isActive();
+
+            List<MealResponseDTO> mealResponseDTOs = MenuConverter.getMealResponseDTOsByMenus(
+                    menuUtil.getDailyMealsByMenuStatus(
+                            restaurantName,
+                            DayOfWeek.valueOf(dayOfWeek),
+                            MenuStatus.APPROVED)
+            );
+
+            DailyMealResponseDTO dailyMealResponseDTO = new DailyMealResponseDTO(dayOfWeek, mealResponseDTOs);
+
+            ApprovedTodayMealResponseDTO approvedTodayMealResponseDTO = new ApprovedTodayMealResponseDTO(restaurantName, isActive, dailyMealResponseDTO);
+
+            approvedTodayMealResponseDTOs.add(approvedTodayMealResponseDTO);
+        }
+
+        return ResponseEntity.ok(SuccessResponse.ok(approvedTodayMealResponseDTOs));
+    }
+
+}


### PR DESCRIPTION
1. 오늘에 해당하는 모든 식당의 식단표 요청 API 추가 (오늘의 학식 클릭)
2. 특정 식당에 대한 상세정보 및 일주일치 식단표 요청API 추가 (지도에서 식당 클릭)
3. 관리자가 등록한 식단 검토 및 수정 후 최종 업로드 API 수정 (응답에 식단표 정보가 포함돼있지 않아 추가시킴)