### PR TITLE
이미지 저장방식 변경에 대한 리펙토링 (두가지 방식)

### DIFF
--- a/src/main/java/sch_helper/sch_manager/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/sch_helper/sch_manager/auth/security/CustomUserDetailsService.java
@@ -17,6 +17,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 
+        // 예외처리 추가
         User userData = userRepository.findByUsername(username);
 
         if (userData != null) {

--- a/src/main/java/sch_helper/sch_manager/common/exception/error/ErrorCode.java
+++ b/src/main/java/sch_helper/sch_manager/common/exception/error/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     MENU_ALREADY_EXISTS(HttpStatus.CONFLICT, "C002", "해당 메뉴는 이미 존재합니다."),
     INVALID_MEAL_TYPE(HttpStatus.CONFLICT, "C003", "잘못된 식단 유형입니다."),
     INVALID_OPERATION(HttpStatus.CONFLICT, "C004", "이 작업을 수행할 수 없습니다."),
+    TRANSFORMATION_ERROR(HttpStatus.CONFLICT, "C005", "데이터 변환 과정에서 오류가 발생했습니다."),
 
     /** ========== 415 UNSUPPORTED_MEDIA_TYPE (잘못된 Content-Type) ========== **/
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "U001", "지원되지 않는 Content-Type입니다."),

--- a/src/main/java/sch_helper/sch_manager/common/util/FileUtil.java
+++ b/src/main/java/sch_helper/sch_manager/common/util/FileUtil.java
@@ -1,13 +1,35 @@
 package sch_helper.sch_manager.common.util;
 
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Paths;
+import java.util.Base64;
 
 @Component
 public class FileUtil {
+
+    public byte[] imageToByte(MultipartFile file) throws IOException {
+
+        return file.getBytes();
+    }
+
+    public byte[] encodeByteToBase64(byte[] byteFile) throws IOException {
+
+        return Base64.getEncoder().encode(byteFile);
+    }
+
+    public byte[] encodeImageToBase64(MultipartFile file) throws IOException {
+
+        byte[] imageBytes = file.getBytes();
+        //return Base64.getEncoder().encodeToString(imageBytes);
+        return Base64.getEncoder().encode(imageBytes);
+    }
 
     public String saveFile(MultipartFile file, String folderName, String fileName) throws IOException {
 
@@ -45,5 +67,24 @@ public class FileUtil {
 
         System.out.println("filePath: " + filePath);
         return filePath;
+    }
+
+    public Resource getFileResource(String folderName, String fileName) {
+        try {
+            // String filePath = getFile(folderName, fileName);
+            String basePath = new File("").getAbsolutePath();
+            String filePath = Paths.get(basePath, folderName, fileName).toString();
+
+            File file = new File(filePath);
+            if (!file.exists()) {
+                System.out.println("파일이 존재하지 않습니다: " + filePath);
+                return null;
+            }
+
+            return new UrlResource(file.toURI());
+        } catch (MalformedURLException e) {
+            System.out.println("파일을 로드하는 중 오류 발생: " + e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/sch_helper/sch_manager/common/util/FileUtil.java
+++ b/src/main/java/sch_helper/sch_manager/common/util/FileUtil.java
@@ -1,90 +1,29 @@
 package sch_helper.sch_manager.common.util;
 
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import sch_helper.sch_manager.common.exception.custom.ApiException;
+import sch_helper.sch_manager.common.exception.error.ErrorCode;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.nio.file.Paths;
 import java.util.Base64;
 
 @Component
 public class FileUtil {
 
-    public byte[] imageToByte(MultipartFile file) throws IOException {
+    public byte[] imageToByte(MultipartFile file) {
 
-        return file.getBytes();
+        byte[] bytes = null;
+        try {
+            bytes = file.getBytes();
+        } catch (IOException e) {
+            throw new ApiException(ErrorCode.TRANSFORMATION_ERROR);
+         }
+        return bytes;
     }
 
-    public byte[] encodeByteToBase64(byte[] byteFile) throws IOException {
+    public byte[] encodeByteToBase64(byte[] byteFile) {
 
         return Base64.getEncoder().encode(byteFile);
-    }
-
-    public byte[] encodeImageToBase64(MultipartFile file) throws IOException {
-
-        byte[] imageBytes = file.getBytes();
-        //return Base64.getEncoder().encodeToString(imageBytes);
-        return Base64.getEncoder().encode(imageBytes);
-    }
-
-    public String saveFile(MultipartFile file, String folderName, String fileName) throws IOException {
-
-        String basePath = new File("").getAbsolutePath();
-        String folderPath = basePath + File.separator + folderName;
-        File directory = new File(folderPath);
-        if (!directory.exists()) {
-            directory.mkdirs();
-            System.out.println("폴더 생성");
-        }
-
-        System.out.println("folderPath : " + folderPath);
-
-        String filePath = folderPath + File.separator + fileName;
-        File destinationFile = new File(filePath);
-        file.transferTo(destinationFile);
-
-        System.out.println("filePath: " + filePath);
-
-        return filePath;
-    }
-
-    public String getFile(String folderName, String fileName) {
-
-        String basePath = new File("").getAbsolutePath();
-        String folderPath = basePath + File.separator + folderName;
-        String filePath = folderPath + File.separator + fileName;
-
-        File file = new File(filePath);
-
-        if (!file.exists()) {
-            System.out.println("파일이 존재하지 않습니다: " + filePath);
-            return null;
-        }
-
-        System.out.println("filePath: " + filePath);
-        return filePath;
-    }
-
-    public Resource getFileResource(String folderName, String fileName) {
-        try {
-            // String filePath = getFile(folderName, fileName);
-            String basePath = new File("").getAbsolutePath();
-            String filePath = Paths.get(basePath, folderName, fileName).toString();
-
-            File file = new File(filePath);
-            if (!file.exists()) {
-                System.out.println("파일이 존재하지 않습니다: " + filePath);
-                return null;
-            }
-
-            return new UrlResource(file.toURI());
-        } catch (MalformedURLException e) {
-            System.out.println("파일을 로드하는 중 오류 발생: " + e.getMessage());
-            return null;
-        }
     }
 }

--- a/src/main/java/sch_helper/sch_manager/common/util/MenuUtil.java
+++ b/src/main/java/sch_helper/sch_manager/common/util/MenuUtil.java
@@ -21,7 +21,7 @@ public class MenuUtil {
     private final MenuRepository menuRepository;
 
     @Transactional
-    public void saveDailyMeal(Restaurant restaurant, DailyMealRequestDTO dailyMealRequestDTO, MenuStatus menuStatus, MenuImage menuImage) {
+    public void saveDailyMeal(Restaurant restaurant, DailyMealRequestDTO dailyMealRequestDTO, MenuStatus menuStatus) {
 
         DayOfWeek dayOfWeek = DayOfWeek.valueOf(dailyMealRequestDTO.getDayOfWeek());
 
@@ -41,9 +41,6 @@ public class MenuUtil {
             menu.setSubMenu(mealRequestDTO.getSubMenu());
             menu.setUnique(uniqueName);
             menu.setMenuStatus(menuStatus);
-            if (menuImage != null) {
-                menu.setMenuImage(menuImage);
-            }
 
             menuRepository.save(menu);
         }

--- a/src/main/java/sch_helper/sch_manager/common/util/MenuUtil.java
+++ b/src/main/java/sch_helper/sch_manager/common/util/MenuUtil.java
@@ -2,16 +2,17 @@ package sch_helper.sch_manager.common.util;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import sch_helper.sch_manager.domain.menu.dto.base.DailyMealRequestDTO;
 import sch_helper.sch_manager.domain.menu.dto.base.MealRequestDTO;
 import sch_helper.sch_manager.domain.menu.entity.Menu;
+import sch_helper.sch_manager.domain.menu.entity.MenuImage;
 import sch_helper.sch_manager.domain.menu.entity.Restaurant;
 import sch_helper.sch_manager.domain.menu.enums.DayOfWeek;
 import sch_helper.sch_manager.domain.menu.enums.MenuStatus;
 import sch_helper.sch_manager.domain.menu.repository.MenuRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -19,8 +20,8 @@ public class MenuUtil {
 
     private final MenuRepository menuRepository;
 
-
-    public void saveDailyMeal(Restaurant restaurant, DailyMealRequestDTO dailyMealRequestDTO, MenuStatus menuStatus) {
+    @Transactional
+    public void saveDailyMeal(Restaurant restaurant, DailyMealRequestDTO dailyMealRequestDTO, MenuStatus menuStatus, MenuImage menuImage) {
 
         DayOfWeek dayOfWeek = DayOfWeek.valueOf(dailyMealRequestDTO.getDayOfWeek());
 
@@ -28,9 +29,9 @@ public class MenuUtil {
 
             String uniqueName = restaurant.getId() + "_" + dayOfWeek + "_" + mealRequestDTO.getMealType() + "_" + menuStatus;
 
-            Optional<Menu> existMenu = menuRepository.findByUnique(uniqueName);
+            Menu menu = menuRepository.findByUnique(uniqueName)
+                    .orElse(new Menu());
 
-            Menu menu = existMenu.orElse(new Menu());
             menu.setRestaurant(restaurant);
             menu.setDayOfWeek(dayOfWeek);
             menu.setMealType(mealRequestDTO.getMealTypeEnum());
@@ -40,6 +41,9 @@ public class MenuUtil {
             menu.setSubMenu(mealRequestDTO.getSubMenu());
             menu.setUnique(uniqueName);
             menu.setMenuStatus(menuStatus);
+            if (menuImage != null) {
+                menu.setMenuImage(menuImage);
+            }
 
             menuRepository.save(menu);
         }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/controller/AdminMenuController.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/controller/AdminMenuController.java
@@ -43,9 +43,10 @@ public class AdminMenuController {
         return adminMenuService.uploadWeeklyMealPlans(restaurantName, weekStartDate, dailyMealRequestDTOS, weeklyMealImg);
     }
 
-    @PostMapping("/meal-plans/{restaurant-name}")
+    @PostMapping("/meal-plans/{restaurant-name}/{day-of-week}")
     public ResponseEntity<?> uploadDailyMealPlans(
             @PathVariable(name = "restaurant-name") String restaurantName,
+            @PathVariable(name = "day-of-week") String dayOfWeek, // 특정 요일 확실하게 알려면 필요함. 아래에 중복되긴 하는데 dto 여러 곳에서 사용해서 냅둬야 할 듯
             @RequestPart("weekStartDate") String weekStartDate,
             @RequestPart(value = "dailyMeals", required = false) @Valid DailyMealRequestDTO dailyMealRequestDTO,
             @RequestPart("dailyMealImg") MultipartFile dailyMealImg
@@ -54,8 +55,19 @@ public class AdminMenuController {
         if (!dateUtil.isSameDayOfWeek(weekStartDate, DayOfWeek.MONDAY)) {
             throw new ApiException(ErrorCode.DATE_DAY_MISMATCH);
         }
+        if (dayOfWeek.isEmpty() &&
+                (
+                        !dayOfWeek.equals(DayOfWeek.MONDAY.toString()) ||
+                                !dayOfWeek.equals(DayOfWeek.TUESDAY.toString()) ||
+                                !dayOfWeek.equals(DayOfWeek.WEDNESDAY.toString()) ||
+                                !dayOfWeek.equals(DayOfWeek.THURSDAY.toString()) ||
+                                !dayOfWeek.equals(DayOfWeek.FRIDAY.toString())
+                )
+        ) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST_DATA);
+        }
 
-        return adminMenuService.uploadDailyMealPlans(restaurantName, weekStartDate, dailyMealRequestDTO, dailyMealImg);
+        return adminMenuService.uploadDailyMealPlans(restaurantName, dayOfWeek, weekStartDate, dailyMealRequestDTO, dailyMealImg);
     }
 
     @GetMapping("/week-meal-plans")

--- a/src/main/java/sch_helper/sch_manager/domain/menu/controller/MasterMenuController.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/controller/MasterMenuController.java
@@ -33,7 +33,7 @@ public class MasterMenuController {
             throw new ApiException(ErrorCode.DATE_DAY_MISMATCH);
         }
 
-        return masterMenuService.uploadDailyMealPlans(restaurantName, dailyMealRequestDTO);
+        return masterMenuService.uploadDailyMealPlans(restaurantName, weekStartDate, dailyMealRequestDTO);
     }
 
     @GetMapping("/week-meal-plans")

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/PendingDailyMealResponseDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/PendingDailyMealResponseDTO.java
@@ -10,8 +10,8 @@ import sch_helper.sch_manager.domain.menu.dto.base.DailyMealResponseDTO;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PendingDailyMealResponseDTO {
 
-    private String dayMealImg;
-    private String weekMealImg;
+    private byte[] dayMealImg;
+    private byte[] weekMealImg;
 
     private DailyMealResponseDTO dailyMeal;
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/PendingWeeklyMealResponseDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/PendingWeeklyMealResponseDTO.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 public class PendingWeeklyMealResponseDTO {
 
-    private String weekMealImg;
+    private byte[] weekMealImg;
 
     private List<DailyMealResponseDTO> dailyMeals;
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/base/MealRequestDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/base/MealRequestDTO.java
@@ -23,7 +23,8 @@ public class MealRequestDTO {
     @NotBlank(message = "mainMenu는 필수 값입니다.")
     private String mainMenu;
 
-    @NotBlank(message = "subMenu는 필수 값입니다.")
+    // 식당이 쉬는 날같은 상황에선 mainMenu에만 "운영하지 않습니다."를 입력하고, subMenu엔 입력할 필요가 없기 때문에 제거하는게 나을듯
+    // @NotBlank(message = "subMenu는 필수 값입니다.")
     private String subMenu;
 
     public MealType getMealTypeEnum() {

--- a/src/main/java/sch_helper/sch_manager/domain/menu/entity/Menu.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/entity/Menu.java
@@ -49,4 +49,8 @@ public class Menu {
     @ManyToOne
     @JoinColumn(name = "restaurant_id", nullable = false)
     private Restaurant restaurant;
+
+    @ManyToOne
+    @JoinColumn(name = "menuImage_id")
+    private MenuImage menuImage;
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/entity/Menu.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/entity/Menu.java
@@ -49,8 +49,4 @@ public class Menu {
     @ManyToOne
     @JoinColumn(name = "restaurant_id", nullable = false)
     private Restaurant restaurant;
-
-    @ManyToOne
-    @JoinColumn(name = "menuImage_id")
-    private MenuImage menuImage;
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/entity/MenuImage.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/entity/MenuImage.java
@@ -1,0 +1,27 @@
+package sch_helper.sch_manager.domain.menu.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class MenuImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "menuImage_id")
+    private Long id;
+
+    // HYANGSEOL1-2025-02-17-week , 이러한 형태로 이미지 구별할 수 있기 때문에 week 필요 X, 또한 이러한 형태로 하면 나중에 해당 엔티티 재사용성있게 사용할 수 있을 듯
+    @Column(name = "image_name", nullable = false)
+    private String imageName;
+
+    @Lob
+    @Column(name = "image_binary", nullable = false)
+    //private String imageBinary;
+    private byte[] imageBinary;
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/entity/MenuImage.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/entity/MenuImage.java
@@ -16,12 +16,9 @@ public class MenuImage {
     @Column(name = "menuImage_id")
     private Long id;
 
-    // HYANGSEOL1-2025-02-17-week , 이러한 형태로 이미지 구별할 수 있기 때문에 week 필요 X, 또한 이러한 형태로 하면 나중에 해당 엔티티 재사용성있게 사용할 수 있을 듯
     @Column(name = "image_name", nullable = false)
     private String imageName;
 
-    @Lob
-    @Column(name = "image_binary", nullable = false)
-    //private String imageBinary;
+    @Column(name = "image_binary", nullable = false, columnDefinition = "LONGBLOB")
     private byte[] imageBinary;
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/repository/MenuImageRepository.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/repository/MenuImageRepository.java
@@ -1,0 +1,13 @@
+package sch_helper.sch_manager.domain.menu.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import sch_helper.sch_manager.domain.menu.entity.MenuImage;
+
+import java.util.Optional;
+
+@Repository
+public interface MenuImageRepository extends JpaRepository<MenuImage, String> {
+
+    Optional<MenuImage> findByImageName(String imageName);
+}

--- a/src/main/java/sch_helper/sch_manager/domain/menu/service/MasterMenuService.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/service/MasterMenuService.java
@@ -18,11 +18,14 @@ import sch_helper.sch_manager.domain.menu.dto.base.DailyMealResponseDTO;
 import sch_helper.sch_manager.domain.menu.dto.base.MealResponseDTO;
 import sch_helper.sch_manager.domain.menu.dto.converter.MenuConverter;
 import sch_helper.sch_manager.domain.menu.entity.Menu;
+import sch_helper.sch_manager.domain.menu.entity.MenuImage;
 import sch_helper.sch_manager.domain.menu.entity.Restaurant;
 import sch_helper.sch_manager.domain.menu.enums.DayOfWeek;
 import sch_helper.sch_manager.domain.menu.enums.MenuStatus;
+import sch_helper.sch_manager.domain.menu.repository.MenuImageRepository;
 import sch_helper.sch_manager.domain.menu.repository.RestaurantRepository;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -30,30 +33,62 @@ import java.util.List;
 public class MasterMenuService {
 
     private final RestaurantRepository restaurantRepository;
+    private final MenuImageRepository menuImageRepository;
     private final MenuUtil menuUtil;
     private final FileUtil fileUtil;
 
     public ResponseEntity<?> uploadDailyMealPlans(
             String restaurantName,
+            String weekStartDate,
             DailyMealRequestDTO dailyMealRequestDTO
     ) {
 
         Restaurant restaurant = restaurantRepository.findByName(restaurantName)
                 .orElseThrow(() -> new ApiException(ErrorCode.RESTAURANT_NOT_FOUND));
 
-        menuUtil.saveDailyMeal(restaurant, dailyMealRequestDTO, MenuStatus.APPROVED);
-        menuUtil.saveDailyMeal(restaurant, dailyMealRequestDTO, MenuStatus.PENDING);
+        // 승인 상태의 menu에선 menuImage 참조가 필 X
+        menuUtil.saveDailyMeal(restaurant, dailyMealRequestDTO, MenuStatus.APPROVED, null);
 
         List<Menu> menus = menuUtil.getDailyMealsByMenuStatus(
                 restaurantName,
                 DayOfWeek.valueOf(dailyMealRequestDTO.getDayOfWeek()),
                 MenuStatus.PENDING
         );
+        // 최종 업데이트 할 때 대기 상태의 업로드된 메뉴이미지 연관관계를 유지시킨 상태로 저장해야 함
+        // Master가 작성한 내용으로 덮어씌우기
+        menuUtil.saveDailyMeal(restaurant, dailyMealRequestDTO, MenuStatus.PENDING, menus.get(0).getMenuImage());
+
+        // 최종 업로드된 상태의 식단표를 DB에서 가져오기
+        menus = menuUtil.getDailyMealsByMenuStatus(
+                restaurantName,
+                DayOfWeek.valueOf(dailyMealRequestDTO.getDayOfWeek()),
+                MenuStatus.PENDING
+        );
         List<MealResponseDTO> MealResponseDTOs = MenuConverter.getMealResponseDTOsByMenus(menus);
 
+        String weekImageName = restaurantName + "-" + weekStartDate + "-week";
+        MenuImage weekMenuImage = menuImageRepository.findByImageName(weekImageName)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND));
+
+        byte[] responseWeekImage = null;
+        byte[] responseDayImage = null;
+
+        try {
+            // 일주일 이미지는 필수로 존재
+            responseWeekImage = fileUtil.encodeByteToBase64(weekMenuImage.getImageBinary());
+
+            // 특정 요일 이미지는 존재 안할 수도 있음
+            // 또한 upload로직에서 관리자가 텍스트를 기입하지 않았어도 깡통 menu를 하나 만들어 저장했기 때문에 menus.get(0) 사용
+            if (menus.get(0).getMenuImage() != null) {
+                responseDayImage = fileUtil.encodeByteToBase64(menus.get(0).getMenuImage().getImageBinary());
+            }
+        } catch (IOException e) {
+            throw new ApiException(ErrorCode.DATABASE_ERROR);
+        }
+
         PendingDailyMealResponseDTO pendingDailyMealResponseDTO = new PendingDailyMealResponseDTO(
-                null,
-                null,
+                responseDayImage,
+                responseWeekImage,
                 new DailyMealResponseDTO(dailyMealRequestDTO.getDayOfWeek(), MealResponseDTOs)
         );
 
@@ -62,7 +97,6 @@ public class MasterMenuService {
                 "Daily meal plans Final approval and uploaded successfully.",
                 pendingDailyMealResponseDTO
         ));
-
     }
 
     public ResponseEntity<?> getPendingWeeklyMealPlans(PendingWeeklyMealRequestDTO pendingWeeklyMealRequestDTO) {
@@ -76,17 +110,20 @@ public class MasterMenuService {
         }
         List<DailyMealResponseDTO> DailyMealResponseDTOs = MenuConverter.getDailyMealResponseDTOsByMenus(menus);
 
+        String weekImageName = pendingWeeklyMealRequestDTO.getRestaurantName() + "-" + pendingWeeklyMealRequestDTO.getWeekStartDate().toString() + "-week";
+        MenuImage menuImage = menuImageRepository.findByImageName(weekImageName)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND));
 
-        String restaurantName = pendingWeeklyMealRequestDTO.getRestaurantName();
-        String weekStartDate = pendingWeeklyMealRequestDTO.getWeekStartDate().toString();
+        byte[] weekMealImage = null;
+        try {
 
-        String weekFileName = restaurantName + "-" + weekStartDate + "-week.jpg";
-        String weekMealImgPath = fileUtil.getFile("weeklyMealImg", weekFileName);
+            weekMealImage = fileUtil.encodeByteToBase64(menuImage.getImageBinary());
+        } catch (IOException e) {
+            throw new ApiException(ErrorCode.DATABASE_ERROR);
+        }
 
-
-        // 이미지 경로가 아닌 이미지 보내는 걸로 수정 예정
         PendingWeeklyMealResponseDTO pendingWeeklyMealResponseDTO = new PendingWeeklyMealResponseDTO(
-                weekMealImgPath,
+                weekMealImage,
                 DailyMealResponseDTOs
         );
 
@@ -103,24 +140,42 @@ public class MasterMenuService {
         if (menus.isEmpty()) {
             throw new ApiException(ErrorCode.MENU_NOT_FOUND);
         }
+
         List<MealResponseDTO> MealResponseDTOs = MenuConverter.getMealResponseDTOsByMenus(menus);
 
-
         String dayOfWeek = pendingDailyMealRequestDTO.getDayOfWeek();
-        String restaurantName = pendingDailyMealRequestDTO.getRestaurantName();
-        String weekStartDate = pendingDailyMealRequestDTO.getWeekStartDate().toString();
 
-        String dayFileName = restaurantName + "-" + weekStartDate + "-day.jpg";
-        String weekFileName = restaurantName + "-" + weekStartDate + "-week.jpg";
-
-        String dayMealImgPath = fileUtil.getFile("dailyMealImg", dayFileName);
-        String weekMealImgPath = fileUtil.getFile("weeklyMealImg", weekFileName);
+        byte[] dayMealImage = null;
+        try {
+            dayMealImage = fileUtil.encodeByteToBase64(menus.get(0).getMenuImage().getImageBinary());
 
 
-        // 이미지 경로가 아닌 이미지 보내는 걸로 수정 예정
+            System.out.println(menus.get(0).getMenuImage().getImageName());
+
+
+        } catch (IOException e) {
+            throw new ApiException(ErrorCode.DATABASE_ERROR);
+        }
+
+        String weekImageName = pendingDailyMealRequestDTO.getRestaurantName() + "-" + pendingDailyMealRequestDTO.getWeekStartDate().toString() + "-week";
+        MenuImage weekMenuImage = menuImageRepository.findByImageName(weekImageName)
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND));
+
+
+        System.out.println(weekMenuImage.getImageName());
+
+
+        byte[] weekMealImage = null;
+        try {
+
+            weekMealImage = fileUtil.encodeByteToBase64(weekMenuImage.getImageBinary());
+        } catch (IOException e) {
+            throw new ApiException(ErrorCode.UPLOAD_FAILED);
+        }
+
         PendingDailyMealResponseDTO pendingDailyMealResponseDTO = new PendingDailyMealResponseDTO(
-                dayMealImgPath,
-                weekMealImgPath,
+                dayMealImage,
+                weekMealImage,
                 new DailyMealResponseDTO(dayOfWeek, MealResponseDTOs)
         );
 


### PR DESCRIPTION
기존: 서버 내부의 특정 경로에 이미지를 저장하고, 응답으로 이미지의 경로를 제공
변경: 이미지를 바이너리값으로 DB에 저장하고, 응답으로 반환할 때 Base64로 인코딩하여 제공

V1 : 
menu -> menuImage 단방향 연관관계 (특정 요일에 대한 이미지 참조)
menuImage-imageName (일주일치에 대한 이미지 참조)
업로드 시에 식단 텍스트를 제공받지 않으면 연관관계때문에 로직이 더러워짐

V2 : 
연관관계를 삭제하고, menuImage-imageName필드 자체에 특정 이름을 부여하여 이를 통해 이미지를 구분하여 사용한다.
(이름의 중복문제 때문에 식단표 기능에 대해서만 menuImage테이블 사용 가능)

V2로 생각한 이유:
업로드 시에 식단 텍스트를 제공받지 않으면 연관관계때문에 로직이 더러워짐
어차피 식단표 기능에 대해서만 menuImage테이블을 사용할거라면 V2방식이 단순하고, 직관적이라 생각함.
식단표에 대한 [ 이미지 + 텍스트 / 이미지 ]를 제공받는 상황에 대해 가장 간단하고 쉽게 구현 가능