### PR TITLE
[Feat/Fix] restaurant 활성 상태 스케줄러 / 조기 마감 dto 필드 타입 변경

### DIFF
--- a/src/main/java/sch_helper/sch_manager/SchManagerApplication.java
+++ b/src/main/java/sch_helper/sch_manager/SchManagerApplication.java
@@ -2,8 +2,10 @@ package sch_helper.sch_manager;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class SchManagerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/sch_helper/sch_manager/domain/menu/dto/EarlyCloseRequestDTO.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/dto/EarlyCloseRequestDTO.java
@@ -1,17 +1,13 @@
 package sch_helper.sch_manager.domain.menu.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class EarlyCloseRequestDTO {
 
-    // mealType 은 필요 없으므로 넣지 않음
-
-    @NotBlank
-    private boolean earlyClose;
+    @NotNull(message = "earlyClose는 필수값입니다.")
+    private Boolean earlyClose;
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/repository/RestaurantRepository.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/repository/RestaurantRepository.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 import sch_helper.sch_manager.domain.menu.entity.Restaurant;
 import sch_helper.sch_manager.domain.menu.enums.RestaurantName;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +13,5 @@ public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
 
     Boolean existsByName(RestaurantName name);
     Optional<Restaurant> findByName(RestaurantName name);
+    List<Restaurant> findByIsActive(boolean isActive);
 }

--- a/src/main/java/sch_helper/sch_manager/domain/menu/service/AdminMenuService.java
+++ b/src/main/java/sch_helper/sch_manager/domain/menu/service/AdminMenuService.java
@@ -275,7 +275,7 @@ public class AdminMenuService {
         Restaurant restaurant = restaurantRepository.findByName(RestaurantName.valueOf(restaurantName))
                 .orElseThrow(() -> new ApiException(ErrorCode.RESTAURANT_NOT_FOUND));
 
-        restaurant.changeIsActive(!earlyCloseRequestDTO.isEarlyClose());
+        restaurant.changeIsActive(!earlyCloseRequestDTO.getEarlyClose());
         RestaurantResponseDTO response = RestaurantConverter.toResponse(restaurant);
 
 

--- a/src/main/java/sch_helper/sch_manager/scheduler/restaurant/RestaurantScheduler.java
+++ b/src/main/java/sch_helper/sch_manager/scheduler/restaurant/RestaurantScheduler.java
@@ -1,0 +1,59 @@
+package sch_helper.sch_manager.scheduler.restaurant;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import sch_helper.sch_manager.domain.menu.entity.Restaurant;
+import sch_helper.sch_manager.domain.menu.repository.RestaurantRepository;
+
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RestaurantScheduler {
+
+    private static final Map<LocalTime, Boolean> SCHEDULE_MAP = Map.of(
+            LocalTime.of(8, 0), true,    // 08:00 활성화
+            LocalTime.of(11, 0), true,   // 11:00 활성화
+            LocalTime.of(17, 0), true,   // 17:00 활성화
+            LocalTime.of(9, 30), false,  // 09:30 비활성화
+            LocalTime.of(14, 0), false,  // 14:00 비활성화
+            LocalTime.of(19, 0), false  // 19:00 비활성화
+    );
+
+    private final RestaurantRepository restaurantRepository;
+
+    @Scheduled(cron = "0 0 8,11,17 * * *", zone = "Asia/Seoul") // 활성화 시간대 (08:00, 11:00, 17:00)
+    @Scheduled(cron = "0 30 9 * * *", zone = "Asia/Seoul")      // 비활성화 시간대 (09:30)
+    @Scheduled(cron = "0 0 14,19 * * *", zone = "Asia/Seoul")  // 비활성화 시간대 (14:00, 19:00)
+    public void updateRestaurantStatus() {
+        LocalTime now = LocalTime.now().truncatedTo(ChronoUnit.MINUTES); // 초 제거
+        log.info("식당 상태 강제 업데이트 실행 - {}", now);
+
+        if (!SCHEDULE_MAP.containsKey(now)) {
+            log.info("해당 시간대 작업 없음");
+            return;
+        }
+
+        boolean targetStatus = SCHEDULE_MAP.get(now);
+        List<Restaurant> targets = restaurantRepository.findByIsActive(!targetStatus);
+
+        targets.forEach(restaurant -> {
+            restaurant.changeIsActive(targetStatus);
+            log.debug("{} 상태 변경: {} → {}",
+                    restaurant.getName(), !targetStatus, targetStatus);
+        });
+
+        restaurantRepository.saveAll(targets);
+        log.info("{}개 식당 {} 처리", targets.size(),
+                targetStatus ? "활성화" : "비활성화");
+    }
+
+}
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,0 @@
-#spring.application.name=SCH_Manager
-#
-#spring.profiles.include=secret
-#
-#logging.level.root=INFO
-#logging.level.org.springframework.security=DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,47 @@
+spring:
+  application:
+    name: SCH_Manager
+  profiles:
+    include: secret
+  jwt:
+    secret: ${JWT_SECRET}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+
+  datasource:
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_TABLE}?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+
+  servlet:
+    multipart:
+      max-request-size: 50MB
+      max-file-size: 50MB
+
+  security:
+    user:
+      name: ${SECURITY_NAME}
+      password: ${SECURITY_PASSWORD}
+logging:
+  level:
+    root: info
+
+management:
+  metrics:
+    enable:
+      process: false    # ???? ??? ????
+      system: false     # ??? ??? ????
+    binder:
+      cpu: false        # CPU ??? ?? ??


### PR DESCRIPTION
### 식당 활성 상태 스케줄링 ###
* 08:00, 11:00, 17:00에 모든 식당 활성화 처리
* 09:30, 14:00, 19:00에 모든 식당 비활성화 처리

✓ 30분마다 스케줄러를 실행해서 활성 상태 업데이트를 하려고 했는데, 그렇게 되면 조기 마감을 해도 운영 시간이라면 스케줄러에 의해  다시 운영중으로 바뀌기 때문에 운영 시간 분기마다 스케줄러를 수행하도록 구현

### 조기 마감 dto 필드 래퍼타입으로 변경 ###
 * validate를 위해 래퍼타입으로 변경